### PR TITLE
Upgrade lindera dependency from 2.0.1 to 5.0.1

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -64,4 +64,4 @@ jobs:
           components: rustfmt, clippy
 
       - name: Run test
-        run: cargo test --target "${{ matrix.platform.target }}" --all-features ${{ matrix.platform.skip_test_run == true && '--no-run' || '' }}
+        run: cargo test --target "${{ matrix.platform.target }}" --features=embed-cjk ${{ matrix.platform.skip_test_run == true && '--no-run' || '' }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -67,4 +67,4 @@ jobs:
           components: rustfmt, clippy
 
       - name: Run test
-        run: cargo test --target "${{ matrix.platform.target }}" --all-features ${{ matrix.platform.skip_test_run == true && '--no-run' || '' }}
+        run: cargo test --target "${{ matrix.platform.target }}" --features=embed-cjk ${{ matrix.platform.skip_test_run == true && '--no-run' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,6 @@ jobs:
             target: aarch64-pc-windows-msvc
             skip_test_run: true
         toolchain: [stable]
-        features: ["cjk"]
     runs-on: ${{ matrix.platform.runner }}
     env:
       LINDERA_CONFIG_PATH: "./resources/lindera.yml"
@@ -70,7 +69,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Run test
-        run: cargo test --target "${{ matrix.platform.target }}" --all-features ${{ matrix.platform.skip_test_run == true && '--no-run' || '' }}
+        run: cargo test --target "${{ matrix.platform.target }}" --features=embed-cjk ${{ matrix.platform.skip_test_run == true && '--no-run' || '' }}
 
   create-release:
     name: Create release
@@ -138,12 +137,15 @@ jobs:
           - value: "embed-cc-cedict"
             package_name: "lindera-sqlite-cc-cedict"
             package_description: "Python binding for Lindera with CHinese dictionary (CC-CEDICT)"
+          - value: "embed-jieba"
+            package_name: "lindera-sqlite-jieba"
+            package_description: "Python binding for Lindera with Chinese dictionary (Jieba)"
           - value: "embed-cjk"
             package_name: "lindera-sqlite"
-            package_description: "Python binding for Lindera with CJK dictionaries (IPADIC, ko-dic, CC-CEDICT)"
+            package_description: "Python binding for Lindera with CJK dictionaries (IPADIC, ko-dic, Jieba)"
     runs-on: ${{ matrix.platform.runner }}
     env:
-      LINDERA_CONFIG_PATH: "./resources/lindera.json"
+      LINDERA_CONFIG_PATH: "./resources/lindera.yml"
     permissions:
       contents: write
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,23 +13,29 @@ license = "MIT"
 
 [features]
 embed-ipadic = [
-    "lindera/embed-ipadic",
+    "lindera-analysis/embed-ipadic",
 ] # Include Japanese dictionary (IPADIC)
 embed-ipadic-neologd = [
-    "lindera/embed-ipadic-neologd",
+    "lindera-analysis/embed-ipadic-neologd",
 ] # Include Japanese dictionary (IPADIC NEologd)
 embed-unidic = [
-    "lindera/embed-unidic",
+    "lindera-analysis/embed-unidic",
 ] # Include Japanese dictionary (UniDic)
 embed-ko-dic = [
-    "lindera/embed-ko-dic",
+    "lindera-analysis/embed-ko-dic",
 ] # Include Korean dictionary (ko-dic)
 embed-cc-cedict = [
-    "lindera/embed-cc-cedict",
+    "lindera-analysis/embed-cc-cedict",
 ] # Include Chinese dictionary (CC-CEDICT)
+embed-jieba = [
+    "lindera-analysis/embed-jieba",
+] # Include Chinese dictionary (Jieba)
 embed-cjk = [
-    "lindera/embed-cjk",
-] # Include CJK dictionary (Chinese, Japanese, Korean)
+    "embed-ipadic",
+    "embed-ko-dic",
+    "embed-jieba",
+] # Include CJK dictionaries (IPADIC, ko-dic, Jieba). Mirrors lindera 5.0.1's
+# `embed-cjk`; re-check this composition when bumping the lindera dependency.
 extension = []
 default = ["extension"] # No directories included
 
@@ -47,13 +53,10 @@ panic = "abort"   # Abort on panic for smaller binary and faster code
 [dependencies]
 # libc without `std`
 libc = { version = "0.2.180", default-features = false, features = [] }
-serde_json = "1.0.149"
 sqlite-loadable = "0.0.6-alpha.6"
 sqlite3ext-sys = "0.0.1"
-unicode-segmentation = "1.12.0"
-unicode-normalization = "0.1.25"
 
-lindera = "2.0.1"
+lindera-analysis = "5.0.1"
 
 [dev-dependencies]
 criterion = "0.8.1"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ When used as a custom FTS5 tokenizer this enables application to support Chinese
 % cargo build --features=embed-cjk
 ```
 
+Each `embed-*` feature embeds a different set of dictionaries into the built extension:
+
+| Feature | Embedded dictionaries |
+| --- | --- |
+| `embed-ipadic` | Japanese (IPADIC) |
+| `embed-ipadic-neologd` | Japanese (IPADIC NEologd) |
+| `embed-unidic` | Japanese (UniDic) |
+| `embed-ko-dic` | Korean (ko-dic) |
+| `embed-cc-cedict` | Chinese (CC-CEDICT) |
+| `embed-jieba` | Chinese (Jieba) |
+| `embed-cjk` | Japanese (IPADIC) + Korean (ko-dic) + Chinese (Jieba) |
+
 ## Set enviromment variable for Lindera configuration
 
 ```sh

--- a/src/common.rs
+++ b/src/common.rs
@@ -7,7 +7,7 @@ use core::convert::TryFrom;
 
 use libc::{c_char, c_int, c_void};
 
-use lindera::tokenizer::Tokenizer;
+use lindera_analysis::tokenizer::Tokenizer;
 
 // sqlite3.h
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! ## Features
 //!
 //! - **CJK Language Support**: Tokenizes Chinese, Japanese, and Korean text using Lindera
-//! - **Multiple Dictionaries**: Supports various embedded dictionaries (IPADIC, UniDic, ko-dic, CC-CEDICT)
+//! - **Multiple Dictionaries**: Supports various embedded dictionaries (IPADIC, UniDic, ko-dic, CC-CEDICT, Jieba)
 //! - **Configurable**: Uses YAML configuration for character filters and token filters
 //! - **SQLite Integration**: Seamlessly integrates with SQLite's FTS5 full-text search
 //!
@@ -15,7 +15,7 @@
 //! ### Building the Extension
 //!
 //! ```bash
-//! cargo build --release --features=embedded-cjk
+//! cargo build --release --features=embed-cjk
 //! ```
 //!
 //! ### Setting Up Configuration
@@ -62,7 +62,7 @@ mod extension;
 
 use libc::{c_char, c_int, c_uchar, c_void};
 
-use lindera::tokenizer::{Tokenizer, TokenizerBuilder};
+use lindera_analysis::tokenizer::{Tokenizer, TokenizerBuilder};
 
 pub use crate::common::*;
 


### PR DESCRIPTION
## Summary

- Move from `lindera = "2.0.1"` to `lindera-analysis = "5.0.1"`. lindera 5.0.0 split the tokenizer/analysis-chain API (character filters, token filters, `TokenizerBuilder`/`Tokenizer`) out of the `lindera` crate into a new `lindera-analysis` crate; the pure segmenter stays in `lindera`. The API surface (`TokenizerBuilder::new()`/`.build()`, `Tokenizer::tokenize()`, `Token.surface`/`.byte_start`/`.byte_end`), the `LINDERA_CONFIG_PATH` env var, and the YAML config schema are all unchanged, so `src/lib.rs`/`src/common.rs` only needed an import-path swap — no tokenization logic changed.
- Rework `embed-*` Cargo features to forward through `lindera-analysis`, and add `embed-jieba`.
- Fix CI's test step (`--all-features` → `--features=embed-cjk`) and a `release.yml` config-path typo; document which dictionary each `embed-*` feature embeds in the README.

## Breaking changes

1. **`embed-cjk` now embeds Jieba instead of CC-CEDICT for Chinese.** This mirrors upstream lindera 5.0.1's own `embed-cjk` definition (`IPADIC + ko-dic + Jieba`, changed from `IPADIC + ko-dic + CC-CEDICT` in lindera 2.x). Since lindera 5.x gates `DictionaryKind::CcCedict` behind the `embed-cc-cedict` feature specifically, anyone with `dictionary: "embedded://cc-cedict"` in their `lindera.yml` who builds with `embed-cjk` needs to either switch to the standalone `embed-cc-cedict` feature build, or repoint their config at `embedded://jieba`.
2. **Built artifacts are significantly larger.** lindera 5.0.0 dropped the `compress` feature entirely (dictionaries are now embedded uncompressed for rkyv zero-copy loading). Locally, the `embed-cjk` release binary grew from 41.9 MB to 234 MB (~5.6x).

## Why `--all-features` → `--features=embed-cjk` in CI

`--all-features` would now build all 6 dictionaries uncompressed in a single CI job. Upstream lindera itself hit disk-space failures embedding even a *single* uncompressed dictionary per job (lindera#752) and had to add cleanup steps. Per-dictionary build coverage is already provided by this workflow's existing `build` job matrix (one job per `embed-*` feature), so switching the `test` job to `embed-cjk` only doesn't reduce coverage, just avoids stacking all 6 dictionaries in one job across 6 platforms including macOS/Windows.

## Test plan

- [x] `cargo build --features=embed-cjk`
- [x] `LINDERA_CONFIG_PATH=./resources/lindera.yml cargo test --features=embed-cjk` — 2 tests + 1 doctest pass, including `it_emits_segments`'s exact byte-offset assertions (the main regression risk, since `OffsetMapping::correct_offset` was internally rewritten upstream between v2 and v5)
- [x] Each `embed-*` feature builds standalone with no cross-dependency
- [x] `cargo fmt --all -- --check` clean; `cargo clippy --features=embed-cjk` has one pre-existing warning in `src/extension.rs`, untouched by this PR
- [x] End-to-end: loaded the built extension into a real `sqlite3` session, created an FTS5 table, inserted Japanese text, confirmed `MATCH` returns correct results. (Loading against unpatched `main` currently fails due to the unrelated, already-open #34 bug — reproduced identically on both `main` and this branch to confirm this PR isn't the cause; verified tokenization end-to-end with #34's fix applied temporarily, then reverted before committing here since fixing #34 is out of scope for this PR.)

Closes #35