### PR TITLE
Fix extension initialization: bind the address of the fts5_api out-pointer, and accept iVersion >= 2

### DIFF
--- a/src/extension.rs
+++ b/src/extension.rs
@@ -26,10 +26,11 @@ use crate::common::*;
 use crate::lindera_fts5_tokenize;
 use crate::load_tokenizer;
 
-/// FTS5 API version supported by this extension.
+/// Minimum FTS5 API version this extension requires.
 ///
-/// This constant indicates compatibility with SQLite FTS5 API version 2.
-/// The extension will verify this version matches at runtime during initialization.
+/// Version 2 is all this extension needs — it registers a tokenizer through `xCreateTokenizer`.
+/// Newer APIs are accepted at runtime, since the structure only ever grows (see
+/// `ensure_fts5_api_version`).
 pub const FTS5_API_VERSION: c_int = 2;
 
 /// Opaque SQLite database handle.
@@ -79,11 +80,13 @@ struct Fts5TokenizerApi {
 ///
 /// # Fields
 ///
-/// - `i_version` - API version number (must be 2)
+/// - `i_version` - API version number (2 or greater; SQLite 3.47.0 and later report 3)
 /// - `x_create_tokenizer` - Function to register a new tokenizer with FTS5
 #[repr(C)]
 struct FTS5API {
-    i_version: c_int, // Currently always set to 2
+    // Only the leading members are declared here — the real struct grows with each SQLite
+    // release, and new members are always appended, so this prefix stays ABI-compatible.
+    i_version: c_int,
 
     /* Create a new tokenizer */
     x_create_tokenizer: extern "C" fn(
@@ -143,11 +146,18 @@ impl<'a> SqliteApi<'a> {
         target: &mut *mut FTS5API,
     ) -> Result<(), c_int> {
         let bind_pointer = self.raw.bind_pointer.ok_or(SQLITE_INTERNAL)?;
+        // Bind the ADDRESS of the out-variable, matching SQLite's documented pattern:
+        //
+        //     fts5_api *pRet = 0;
+        //     sqlite3_bind_pointer(pStmt, 1, (void*)&pRet, "fts5_api_ptr", NULL);
+        //
+        // `target.cast()` would auto-deref the `&mut *mut FTS5API` and pass the pointer's own
+        // (null) VALUE instead, so fts5() had nowhere to write and `p_fts5_api` stayed null.
         let rc = unsafe {
             bind_pointer(
                 stmt,
                 1,
-                target.cast::<c_void>(),
+                (&raw mut *target).cast::<c_void>(),
                 c"fts5_api_ptr".as_ptr() as *const c_char,
                 None,
             )
@@ -307,7 +317,15 @@ fn lindera_fts_tokenizer_internal_init(
 }
 
 fn ensure_fts5_api_version(fts5_api: &FTS5API) -> Result<(), c_int> {
-    if fts5_api.i_version == FTS5_API_VERSION {
+    // Accept any API at or above the version this extension targets, rather than an exact match.
+    //
+    // SQLite 3.47.0 raised `fts5_api.iVersion` from 2 to 3 (adding `fts5_tokenizer_v2` with
+    // `xCreateTokenizer_v2` / `xFindTokenizer_v2`), so an equality test rejects every SQLite
+    // released since. The change is purely additive — `xCreateTokenizer`, the only entry point
+    // this extension uses, is unchanged and keeps its position in the struct, with the v2 members
+    // appended after `xCreateFunction`. Only an OLDER API, missing members we rely on, is a
+    // genuine mismatch.
+    if fts5_api.i_version >= FTS5_API_VERSION {
         Ok(())
     } else {
         Err(SQLITE_MISUSE)


### PR DESCRIPTION
Fixes #34.

The extension could not be loaded at all in the LTS version of `node:sqlite` because `lindera_fts5_tokenizer_init` always returned an error. There are **two** bugs on that path, and both have to be fixed for the extension to initialize; the second is only reachable once the first is fixed.

## 1. `bind_fts5_pointer` passed the pointer's value, not its address

SQLite's documented way to obtain the FTS5 API is [`fts5_api_from_db`, from *FTS5 §7 Extending FTS5*](https://www.sqlite.org/fts5.html#extend_fts5):

```c
fts5_api *pRet = 0;
sqlite3_bind_pointer(pStmt, 1, (void*)&pRet, "fts5_api_ptr", NULL);
sqlite3_step(pStmt);
```

Note `&pRet` — fts5() writes the api pointer *into* that variable.

`target` here is `&mut *mut FTS5API`, so `target.cast::<c_void>()` auto-derefs the reference and passes the inner `*mut FTS5API` (i.e. `pRet`'s own value, which is null at that moment) instead of `&pRet`. `sqlite3_bind_pointer` returns `SQLITE_OK` and `sqlite3_step` returns `SQLITE_ROW`, because nothing is technically wrong; fts5() simply has nowhere to write. `p_fts5_api` stays null and init fails at `ok_or(SQLITE_INTERNAL)`.

Instrumented, before the fix:

```
bind rc=0  step rc=100 (SQLITE_ROW)  p_fts5_api null? true
```

The fix binds `(&raw mut *target)`, matching the C pattern.

## 2. `ensure_fts5_api_version` required exactly 2

Once the pointer arrives, init fails at the next gate. SQLite 3.47.0 (2024-10-21) raised `fts5_api.iVersion` from 2 to 3, adding `fts5_tokenizer_v2` with `xCreateTokenizer_v2` / `xFindTokenizer_v2` ([3.47.0 changelog](https://www.sqlite.org/changes.html)). [`ext/fts5/fts5.h`](https://github.com/sqlite/sqlite/blob/master/ext/fts5/fts5.h) now reads:

```c
struct fts5_api {
  int iVersion;                   /* Currently always set to 3 */
```

The bump is purely additive: `xCreateTokenizer` (the only entry point this extension uses) is unchanged and keeps its position in the struct, with the v2 members appended after `xCreateFunction`. So,, an exact-match test rejects every SQLite released in the last ~21 months for no reason. Changed to `>=`, which still rejects a genuinely older API that would be missing members we rely on.

## Verification

Built `--release --features=embed-ipadic` and loaded into SQLite 3.53.0 via Node's built-in `node:sqlite`:

```
LOAD: OK

  hit   MATCH "日本語"   -> 1 row(s)
  hit   MATCH "辞書"     -> 1 row(s)
  hit   MATCH "図書館"   -> 1 row(s)
  hit   MATCH "食べる"   -> 1 row(s)
  hit   MATCH "コーヒー" -> 1 row(s)

5/5 matched
```

Every one of those scores 0 with the stock `unicode61` tokenizer, so this exercises real Lindera segmentation end to end. `cargo test --release --features=embed-ipadic` passes (2 tests + 1 doctest), and `cargo fmt --check` is clean. `cargo clippy` reports one pre-existing `collapsible_if` warning in `Drop for PreparedStatement`, untouched by this change.

Re-verified after rebasing onto `main` at #36 (lindera 2.0.1 → 5.0.1): builds clean, same 5/5, tests and `fmt --check` still pass.